### PR TITLE
Update tweep.py - add "km" directly in the code

### DIFF
--- a/tweep.py
+++ b/tweep.py
@@ -24,6 +24,7 @@ async def getUrl(init):
     if arg.g != None:
         arg.g = arg.g.replace(" ", "")
         url+= "geocode%3A{0.g}".format(arg)
+        url+= "km"
     if arg.s != None:
         arg.s = arg.s.replace(" ", "%20").replace("#", "%23")
         url+= "%20{0.s}".format(arg)


### PR DESCRIPTION
Finally decided to add "km" directly in the code when passing the -g argument.
It's not necessary to pass it manually anymore.
So for instance '48.880048,2.385939,0.5' should work like a charm. (instead of '48.880048,2.385939,0.5km')