### PR TITLE
Replace all emoticons with their title, to be included in the tweet text

### DIFF
--- a/tweep.py
+++ b/tweep.py
@@ -127,6 +127,9 @@ async def outTweet(tweet):
     # The @ in the username annoys me.
     username = tweet.find("span", "username").text.replace("@", "")
     timezone = strftime("%Z", gmtime())
+    # Replace all emoticons with their title, to be included in the tweet text
+    for img in tweet.findAll("img", "Emoji Emoji--forText"):
+        img.replaceWith("<%s>" % img['aria-label'])
     # The context of the Tweet compressed into a single line.
     text = tweet.find("p", "tweet-text").text.replace("\n", "").replace("http", " http").replace("pic.twitter", " pic.twitter")
     # Regex for gathering hashtags


### PR DESCRIPTION
With the current settings, emoticons are being ignored in the tweet text. This PR will replace all emoticons with their title. 
ex: 😜 will be replaced with <Emoji: Face with stuck-out tongue and winking eye>